### PR TITLE
remove tsconfig's path mapping

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,14 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: {
-      "@client": path.resolve(__dirname, "./src"),
-      "@server": path.resolve(__dirname, "../server/src"),
-      "@shared": path.resolve(__dirname, "../shared/src")
-    }
-  }
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,14 +8,6 @@
     "jsx": "react-jsx",
     "allowJs": true,
 
-    // Path resolution
-    "baseUrl": "./",
-    "paths": {
-      "@server/*": ["./server/src/*"],
-      "@client/*": ["./client/src/*"],
-      "@shared/*": ["./shared/src/*"]
-    },
-
     // Module resolution
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Bun/Pnpm/npm workspaces does not use tsconfig path mapping in the root dir, so the removed lines are 100% unused code. The workspace configurations already link the internal repos, and TypeScript understand that. 

Tsconfig's path mapping may used inside internal monorepo packages (inside client/server/shared tsconfig).
Even better [Node.js Subpath Imports](https://turborepo.com/docs/guides/tools/typescript#use-nodejs-subpath-imports-instead-of-typescript-compiler-paths).

More info: 
https://bun.sh/docs/install/workspaces
https://thijs-koerselman.medium.com/my-quest-for-the-perfect-ts-monorepo-62653d3047eb
https://medium.com/@oluijks/setting-up-a-bun-workspace-23543df61e52
https://github.com/mguay22/turbo-full-stack